### PR TITLE
fix: ensure JPA entities are mapped before datasource initialization

### DIFF
--- a/02-jpa-advanced/Step04.md
+++ b/02-jpa-advanced/Step04.md
@@ -221,6 +221,9 @@ logging.level.org.hibernate.stat=debug
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type=trace
+
+spring.jpa.defer-datasource-initialization=true
+
 ```
 ---
 


### PR DESCRIPTION
### Problem
The application was encountering issues with JPA entities not being properly mapped to the database tables on startup.

### Solution
Added `spring.jpa.defer-datasource-initialization=true` to the `application.properties` file. This setting defers the initialization of the datasource until after all JPA entities have been processed, ensuring the tables are correctly mapped.

### Impact
This change ensures that the application's database schema is properly initialized without manual table creation.

Have a read here if you want to know more;
https://www.baeldung.com/spring-boot-h2-jdbcsqlsyntaxerrorexception-table-not-found